### PR TITLE
Improve sanitize headings

### DIFF
--- a/src/mdast-fix-code-flow.js
+++ b/src/mdast-fix-code-flow.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 /* eslint-disable no-param-reassign */
-import { visit } from 'unist-util-visit';
+import { visit, CONTINUE } from 'unist-util-visit';
 
 /**
  * ensures that `code` is at a flow level. i.e. outside a paragraph
@@ -50,7 +50,7 @@ export default function fixCodeFlow(tree) {
       }
     }
     // return index;
-    return visit.CONTINUE;
+    return CONTINUE;
   });
   return tree;
 }

--- a/src/mdast-robust-tables.js
+++ b/src/mdast-robust-tables.js
@@ -12,7 +12,7 @@
 /* eslint-disable no-param-reassign */
 import { toHast as md2hast } from 'mdast-util-to-hast';
 import { toHtml as hast2html } from 'hast-util-to-html';
-import { visit } from 'unist-util-visit';
+import { visit, CONTINUE } from 'unist-util-visit';
 
 /**
  * Converts tables to HTML
@@ -23,7 +23,7 @@ import { visit } from 'unist-util-visit';
 export default function robustTables(tree) {
   visit(tree, (node) => {
     if (node.type !== 'table') {
-      return visit.CONTINUE;
+      return CONTINUE;
     }
     let html = '<table>\n';
     (node.children /* c8 ignore next */ || []).forEach((row) => {
@@ -71,7 +71,7 @@ export default function robustTables(tree) {
     node.type = 'html';
     node.value = html;
     delete node.children;
-    return visit.CONTINUE;
+    return CONTINUE;
   });
   return tree;
 }

--- a/src/mdast-sanitize-formats.js
+++ b/src/mdast-sanitize-formats.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { visit } from 'unist-util-visit';
+import { visit, CONTINUE } from 'unist-util-visit';
 
 /**
  * Sanitizes text:
@@ -43,7 +43,7 @@ export default function sanitizeFormats(tree) {
         }
       }
     }
-    return visit.CONTINUE;
+    return CONTINUE;
   });
   return tree;
 }

--- a/src/mdast-sanitize-heading.js
+++ b/src/mdast-sanitize-heading.js
@@ -13,36 +13,49 @@ import { visit } from 'unist-util-visit';
 
 /**
  * Sanitizes headings:
- * - (re)move images
+ * - (re)move images ('before', 'both', 'after')
  *
  * @param {object} tree
+ * @param {object} [opts] options
+ * @param {string} [opts.imageHandling] specifies how images are handled. defaults to 'after'.
  * @returns {object} The modified (original) tree.
  */
-export default function sanitizeHeading(tree) {
+export default function sanitizeHeading(tree, opts = {}) {
+  const { imageHandling = 'after' } = opts;
   visit(tree, (node, index, parent) => {
     const { children: siblings = [] } = parent || {};
     const { children = [] } = node;
+    let after = index + 1;
     if (node.type === 'heading') {
       for (let i = 0; i < children.length; i += 1) {
         const child = children[i];
         if (child.type === 'image') {
-          // move after heading
-          children.splice(i, 1);
-          i -= 1;
           const para = {
             type: 'paragraph',
             children: [child],
           };
-          siblings.splice(index + 1, 0, para);
+          children.splice(i, 1);
+          i -= 1;
+          if ((i < 0 && imageHandling !== 'after') || imageHandling === 'before') {
+            // move before heading
+            siblings.splice(index, 0, para);
+            // eslint-disable-next-line no-param-reassign
+            index += 1;
+            after = index + 1;
+          } else {
+            // move after heading
+            siblings.splice(after, 0, para);
+            after += 1;
+          }
         }
       }
       // remove empty headings
       if (!children.length) {
         siblings.splice(index, 1);
-        return index;
+        after -= 1;
       }
     }
-    return visit.CONTINUE;
+    return after;
   });
   return tree;
 }

--- a/src/mdast-sanitize-links.js
+++ b/src/mdast-sanitize-links.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { visit } from 'unist-util-visit';
+import { visit, CONTINUE } from 'unist-util-visit';
 import find from 'unist-util-find';
 
 /**
@@ -61,7 +61,7 @@ export default function sanitizeLinks(tree) {
         }
       }
     }
-    return visit.CONTINUE;
+    return CONTINUE;
   });
   return tree;
 }

--- a/src/mdast-sanitize-text.js
+++ b/src/mdast-sanitize-text.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { visit } from 'unist-util-visit';
+import { visit, CONTINUE } from 'unist-util-visit';
 
 /**
  * Sanitizes text:
@@ -107,7 +107,7 @@ export default function sanitizeText(tree) {
         }
       }
     }
-    return visit.CONTINUE;
+    return CONTINUE;
   });
   return tree;
 }

--- a/src/mdast-suppress-spacecode.js
+++ b/src/mdast-suppress-spacecode.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { visit } from 'unist-util-visit';
+import { visit, CONTINUE } from 'unist-util-visit';
 
 /**
  * Looks for text starting with 4 spaces. As this would render as code in some markdown,
@@ -27,7 +27,7 @@ export default function suppressSpaceCode(tree) {
       // eslint-disable-next-line no-param-reassign
       child.value = child.value.replace(/^\s+/, ' ');
     }
-    return visit.CONTINUE;
+    return CONTINUE;
   });
   return tree;
 }

--- a/test/fixtures/sanitized-heading-before.md
+++ b/test/fixtures/sanitized-heading-before.md
@@ -1,7 +1,7 @@
-## This contains an image: .
-
 ![](https://dummyimage.com/300 "Dummy Image 1")
 
 ![](https://dummyimage.com/300 "Dummy Image 2")
+
+## This contains an image: .
 
 Hello, world.

--- a/test/fixtures/sanitized-heading-both.md
+++ b/test/fixtures/sanitized-heading-both.md
@@ -1,0 +1,21 @@
+![](https://dummyimage.com/300 "Dummy Image 1")
+
+![](https://dummyimage.com/300 "Dummy Image 2")
+
+## This contains an image: .
+
+![](https://dummyimage.com/300 "Dummy Image 3")
+
+![](https://dummyimage.com/300 "Dummy Image 4")
+
+![](https://dummyimage.com/300 "Dummy Image 5")
+
+![](https://dummyimage.com/300 "Dummy Image 6")
+
+## This also contains images: .
+
+![](https://dummyimage.com/300 "Dummy Image 7")
+
+![](https://dummyimage.com/300 "Dummy Image 8")
+
+Hello, world.

--- a/test/fixtures/sanitized-heading-empty.md
+++ b/test/fixtures/sanitized-heading-empty.md
@@ -1,0 +1,1 @@
+Hello, world.

--- a/test/remark-matter-from-md.test.js
+++ b/test/remark-matter-from-md.test.js
@@ -15,7 +15,7 @@ import jsYaml from 'js-yaml';
 import { unified } from 'unified';
 import remark from 'remark-parse';
 import { inspectNoColor as inspect } from 'unist-util-inspect';
-import { visit } from 'unist-util-visit';
+import { visit, CONTINUE } from 'unist-util-visit';
 import {
   heading, paragraph, root, text,
 } from 'mdast-builder';
@@ -56,7 +56,7 @@ function removePositions(tree) {
   visit(tree, (node) => {
     // eslint-disable-next-line no-param-reassign
     delete node.position;
-    return visit.CONTINUE;
+    return CONTINUE;
   });
   return tree;
 }

--- a/test/sanitize-headings.test.js
+++ b/test/sanitize-headings.test.js
@@ -18,11 +18,12 @@ import { assertMD } from './utils.js';
 import { sanitizeHeading } from '../src/index.js';
 
 describe('sanitize-heading Tests', () => {
-  it('Moves images in heading to next paragraph.', async () => {
+  it('Moves images in heading to next paragraph. by default', async () => {
     const mdast = root([
       heading(2, [
+        image('https://dummyimage.com/300', 'Dummy Image 1'),
         text('This contains an image: '),
-        image('https://dummyimage.com/300', 'Dummy Image'),
+        image('https://dummyimage.com/300', 'Dummy Image 2'),
         text('.'),
       ]),
       paragraph([
@@ -33,7 +34,65 @@ describe('sanitize-heading Tests', () => {
     await assertMD(mdast, 'sanitized-heading.md');
   });
 
-  it('Removes empty headings.', async () => {
+  it('Moves images in heading to next paragraph if enabled', async () => {
+    const mdast = root([
+      heading(2, [
+        image('https://dummyimage.com/300', 'Dummy Image 1'),
+        text('This contains an image: '),
+        image('https://dummyimage.com/300', 'Dummy Image 2'),
+        text('.'),
+      ]),
+      paragraph([
+        text('Hello, world.'),
+      ]),
+    ]);
+    sanitizeHeading(mdast, { imageHandling: 'after' });
+    await assertMD(mdast, 'sanitized-heading.md');
+  });
+
+  it('Moves images in heading to previous paragraph if enabled', async () => {
+    const mdast = root([
+      heading(2, [
+        image('https://dummyimage.com/300', 'Dummy Image 1'),
+        text('This contains an image: '),
+        image('https://dummyimage.com/300', 'Dummy Image 2'),
+        text('.'),
+      ]),
+      paragraph([
+        text('Hello, world.'),
+      ]),
+    ]);
+    sanitizeHeading(mdast, { imageHandling: 'before' });
+    await assertMD(mdast, 'sanitized-heading-before.md');
+  });
+
+  it('Moves images in heading to previous and next paragraph if enabled', async () => {
+    const mdast = root([
+      heading(2, [
+        image('https://dummyimage.com/300', 'Dummy Image 1'),
+        image('https://dummyimage.com/300', 'Dummy Image 2'),
+        text('This contains an image: '),
+        image('https://dummyimage.com/300', 'Dummy Image 3'),
+        image('https://dummyimage.com/300', 'Dummy Image 4'),
+        text('.'),
+      ]),
+      heading(2, [
+        image('https://dummyimage.com/300', 'Dummy Image 5'),
+        image('https://dummyimage.com/300', 'Dummy Image 6'),
+        text('This also contains images: '),
+        image('https://dummyimage.com/300', 'Dummy Image 7'),
+        image('https://dummyimage.com/300', 'Dummy Image 8'),
+        text('.'),
+      ]),
+      paragraph([
+        text('Hello, world.'),
+      ]),
+    ]);
+    sanitizeHeading(mdast, { imageHandling: 'both' });
+    await assertMD(mdast, 'sanitized-heading-both.md');
+  });
+
+  it('Removes empty headings after all images moved out.', async () => {
     const mdast = root([
       heading(2, [
         image('https://dummyimage.com/300', 'Dummy Image'),
@@ -44,5 +103,17 @@ describe('sanitize-heading Tests', () => {
     ]);
     sanitizeHeading(mdast);
     await assertMD(mdast, 'sanitized-heading-removed.md');
+  });
+
+  it('Removes empty headings.', async () => {
+    const mdast = root([
+      heading(2, [
+      ]),
+      paragraph([
+        text('Hello, world.'),
+      ]),
+    ]);
+    sanitizeHeading(mdast);
+    await assertMD(mdast, 'sanitized-heading-empty.md');
   });
 });


### PR DESCRIPTION
- by default, the `sanitize-headings` works as before, by moving all images after the heading.
- new option: `imageHandling` that can control to also move the leading images infront.
- fixes #83 
- also fixes small error with wrong/missing import of `CONTINUE`