### PR TITLE
fix: properly handle whitespace after sort

### DIFF
--- a/test/fixtures/sanitized-whitespace.md
+++ b/test/fixtures/sanitized-whitespace.md
@@ -20,7 +20,7 @@ Lorem ipsum _dolor_ sit amet.
 
 ## Moves leading whitespace in inner text of link
 
-[ **_dolor_**](https://www.adobe.com "adobe")
+_[ **dolor**](https://www.adobe.com "adobe")_
 
 _begin_ sit amet.
 

--- a/test/sanitize-text-and-formats.test.js
+++ b/test/sanitize-text-and-formats.test.js
@@ -221,7 +221,10 @@ describe('sanitize-text Tests', () => {
       ]),
       paragraph([
         text('Lorem ipsum'),
-        strong(emphasis(text(' dolor '))),
+        strong(emphasis([
+          text(' '),
+          text('dolor '),
+        ])),
         text('sit amet.'),
       ]),
     ]);
@@ -305,8 +308,7 @@ describe('sanitize-text Tests', () => {
       ]);
       const expected = root([
         paragraph([
-          text('Hello, '),
-          text('world.'),
+          text('Hello, world.'),
         ]),
       ]);
       sanitizeTextAndFormats(mdast);


### PR DESCRIPTION
when formats are sorted, it could new collapsible pairs appear that were not handled before. furthermore we should ensure proper whitespace around formats.

fixes indirectly:
- https://github.com/adobe/helix-html-pipeline/issues/384

fixes:
- https://github.com/adobe/helix-word2md/issues/1255