### PR TITLE
fix: ensure format sort order

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "semantic-release-dry": "semantic-release --dry-run --branches $CI_BRANCH",
     "semantic-release": "semantic-release",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",

--- a/src/mdast-sanitize-text-and-formats.js
+++ b/src/mdast-sanitize-text-and-formats.js
@@ -274,5 +274,7 @@ export default function sanitizeTextAndFormats(tree) {
   whitespace(tree);
   cleanup(tree);
   prune(tree);
+  // sort again after cleaning everything
+  sort(tree);
   return tree;
 }

--- a/test/fixtures/space-after-link.md
+++ b/test/fixtures/space-after-link.md
@@ -1,0 +1,3 @@
+# space after link
+
+**_[link followed by space](about:blank "Title")_**

--- a/test/sanitize-text-and-formats.test.js
+++ b/test/sanitize-text-and-formats.test.js
@@ -411,4 +411,29 @@ describe('sanitize-text Tests', () => {
     renderHtmlFormats(mdast);
     await assertMD(mdast, 'sort-formats.md', [gfm]);
   });
+
+  it('space after link', async () => {
+    const mdast = root([
+      heading(1, text('space after link')),
+      paragraph([
+        emphasis(
+          link(
+            'about:blank',
+            'Title',
+            strong(
+              text('link followed by space'),
+            ),
+          ),
+        ),
+        emphasis(
+          strong(
+            text(' '),
+          ),
+        ),
+      ]),
+    ]);
+    sanitizeTextAndFormats(mdast);
+    renderHtmlFormats(mdast);
+    await assertMD(mdast, 'space-after-link.md', [gfm]);
+  });
 });


### PR DESCRIPTION
fixes an issue where a space after a link causes the formats not to sort, eg:

```
│            │   └─3 paragraph[2]
│            │       ├─0 emphasis[1]
│            │       │   └─0 link[1]
│            │       │       │ url: "about:blank"
│            │       │       └─0 strong[1]
│            │       │           └─0 text ":play: Watch overview"
│            │       └─1 emphasis[1]
│            │           └─0 strong[1]
│            │               └─0 text " "
```

after `sanitizeTextAndFormats()` the order of strong and emphasis is wrong:

```
│            │   └─3 paragraph[1]
│            │       └─0 emphasis[1]
│            │           └─0 strong[1]
│            │               └─0 link[1]
│            │                   │ url: "about:blank"
│            │                   └─0 text ":play: Watch overview"
```